### PR TITLE
Add previous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
+## 0.5.0
+
+- Added previous method, to get the previous crons
+
 ## 0.4.0
 
-- Migrate to null safety
-- Upgrade dependencies
+- Migrated to null safety
+- Upgraded dependencies
 
 ## 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0
+
+- Migrate to null safety
+- Upgrade dependencies
+
 ## 0.3.1
 
 - Cron selection definitions now supported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.5.0
 
-- Added previous method, to get the previous crons
+- Added previous method, to get the previous crons: `CronIterator().previous()`
+- BREAKING CHANGE: `HasNext().current()` moved into `CronIterator().current()`
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A cron parser
 
-Spits out next cron dates starting from now or a specific date.
+Spits out next & previous cron dates starting from now or a specific date.
 Please notice that the timezone of the resulting dates are in the
 same timezone provided with Cron().parse(...)
 
@@ -13,11 +13,17 @@ import 'package:timezone/timezone.dart';
 
 main() {
   // by default next cron dates are starting from the current date
-  var cronIterator =  Cron().parse("0 * * * *", "Europe/London");
+  var cronIterator = Cron().parse("0 * * * *", "Europe/London");
   TZDateTime nextDate = cronIterator.next();
   // you can retrieve the current value by using the current method
   TZDateTime currentDate = cronIterator.current(); // same as nextDate
   TZDateTime afterNextDate = cronIterator.next();
+
+  cronIterator = Cron().parse("0 * * * *", "Europe/London");
+  TZDateTime previousDate = cronIterator.previous();
+  // you can retrieve the current value by using the current method
+  TZDateTime currentDate = cronIterator.current(); // same as previousDate
+  TZDateTime beforePreviousDate = cronIterator.previous();
 }
 ```
 
@@ -28,9 +34,13 @@ import 'package:timezone/timezone.dart';
 
 main() {
   TZDateTime startDate = TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
-  var cronIterator =  Cron().parse("0 * * * *", "Europe/London", startDate);
+  var cronIterator = Cron().parse("0 * * * *", "Europe/London", startDate);
   TZDateTime nextDate = cronIterator.next(); // 2020-04-01 01:00:00.000+0100
   TZDateTime afterNextDate = cronIterator.next(); // 2020-04-01 02:00:00.000+0100
+
+  cronIterator = Cron().parse("0 * * * *", "Europe/London", startDate);
+  TZDateTime previousDate = cronIterator.previous(); // 2020-03-31 23:00:00.000+0100
+  TZDateTime beforePreviousDate = cronIterator.previous(); // 2020-03-31 22:00:00.000+0100
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Another example this time with a specific start date:
 ## Links
 
 - [source code][source]
-- contributors: [Ronny Bubke][rbubke]
+- contributors: [Ronny Bubke](https://github.com/rbubke), [Nils Reichardt](https://github.com/nilsreichardt)
 
 [source]: https://github.com/rbubke/cron-parser

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ same timezone provided with Cron().parse(...)
 A simple usage example:
 ```dart
 import 'package:cron_parser/cron_parser.dart';
+import 'package:timezone/timezone.dart';
 
 main() {
   // by default next cron dates are starting from the current date
@@ -23,6 +24,7 @@ main() {
 Another example this time with a specific start date:
 ```dart
 import 'package:cron_parser/cron_parser.dart';
+import 'package:timezone/timezone.dart';
 
 main() {
   TZDateTime startDate = TZDateTime(getLocation("Europe/London"), 2020, 4, 01);

--- a/README.md
+++ b/README.md
@@ -7,28 +7,30 @@ same timezone provided with Cron().parse(...)
 ## Usage
 
 A simple usage example:
+```dart
+import 'package:cron_parser/cron_parser.dart';
 
-    import 'package:cron_parser/cron_parser.dart';
-
-    main() {
-      // by default next cron dates are starting from the current date
-      var cronIterator =  Cron().parse("0 * * * *", "Europe/London");
-      TZDateTime nextDate = cronIterator.next();
-      // you can retrieve the current value by using the current method
-      TZDateTime currentDate = cronIterator.current(); // same as nextDate
-      TZDateTime afterNextDate = cronIterator.next();
-    }
+main() {
+  // by default next cron dates are starting from the current date
+  var cronIterator =  Cron().parse("0 * * * *", "Europe/London");
+  TZDateTime nextDate = cronIterator.next();
+  // you can retrieve the current value by using the current method
+  TZDateTime currentDate = cronIterator.current(); // same as nextDate
+  TZDateTime afterNextDate = cronIterator.next();
+}
+```
 
 Another example this time with a specific start date:
+```dart
+import 'package:cron_parser/cron_parser.dart';
 
-    import 'package:cron_parser/cron_parser.dart';
-
-    main() {
-      TZDateTime startDate = TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
-      var cronIterator =  Cron().parse("0 * * * *", "Europe/London", startDate);
-      TZDateTime nextDate = cronIterator.next(); // 2020-04-01 01:00:00.000+0100
-      TZDateTime afterNextDate = cronIterator.next(); // 2020-04-01 02:00:00.000+0100
-    }
+main() {
+  TZDateTime startDate = TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
+  var cronIterator =  Cron().parse("0 * * * *", "Europe/London", startDate);
+  TZDateTime nextDate = cronIterator.next(); // 2020-04-01 01:00:00.000+0100
+  TZDateTime afterNextDate = cronIterator.next(); // 2020-04-01 02:00:00.000+0100
+}
+```
 
 ## Links
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -8,10 +8,24 @@ void main() {
   TZDateTime nextDate = cronIterator.next();
   TZDateTime afterNextDate = cronIterator.next();
 
-  //specify a start date to get cron dates after this date
+  // specify a start date to get cron dates after this date
   TZDateTime startDate = TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
   cronIterator = Cron().parse("0 * * * *", "Europe/London", startDate);
   nextDate = cronIterator.next(); // 2020-04-01 01:00:00.000+0100
-  var currentDate = cronIterator.current(); // 2020-04-01 01:00:00.000+0100
+  var currentDateNext = cronIterator.current(); // 2020-04-01 01:00:00.000+0100
   afterNextDate = cronIterator.next(); // 2020-04-01 02:00:00.000+0100
+
+  // by default previous cron dates are starting from the current date
+  var cronIteratorPrevious = Cron().parse("0 * * * *", "Europe/London");
+  TZDateTime previousDate = cronIterator.previous();
+  TZDateTime beforePreviousDate = cronIterator.previous();
+
+  // specify a start date to get cron dates before this date
+  TZDateTime startDatePrevious =
+      TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
+  cronIterator = Cron().parse("0 * * * *", "Europe/London", startDatePrevious);
+  previousDate = cronIterator.previous(); // 2020-03-31 23:00:00.000+0100
+  var currentDatePrevious =
+      cronIterator.current(); // 2020-03-31 23:00:00.000+0100
+  beforePreviousDate = cronIterator.previous(); // 2020-03-31 22:00:00.000+0100
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,9 +1,12 @@
 name: cron_parser_example
 description: A cron parser example.
-version: 0.2.1
+version: 0.5.0
+
+publish_to: none
 
 environment:
   sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-  cron_parser: ^0.3.1
+  cron_parser:
+    path: ../

--- a/lib/cron_parser.dart
+++ b/lib/cron_parser.dart
@@ -146,6 +146,8 @@ List<int>? _parseConstraint(dynamic constraint) {
 class _CronIterator implements CronIterator<TZDateTime> {
   _Schedule _schedule;
   TZDateTime _currentDate;
+  bool _nextCalled = false;
+  bool _previousCalled = false;
 
   _CronIterator(this._schedule, this._currentDate) {
     _currentDate = TZDateTime.fromMillisecondsSinceEpoch(_currentDate.location,
@@ -154,6 +156,7 @@ class _CronIterator implements CronIterator<TZDateTime> {
 
   @override
   TZDateTime next() {
+    _nextCalled = true;
     _currentDate = _currentDate.add(Duration(minutes: 1));
     while (true) {
       if (_schedule.months?.contains(_currentDate.month) == false) {
@@ -187,6 +190,7 @@ class _CronIterator implements CronIterator<TZDateTime> {
 
   @override
   TZDateTime previous() {
+    _previousCalled = true;
     _currentDate = _currentDate.subtract(Duration(minutes: 1));
     while (true) {
       if (_schedule.minutes?.contains(_currentDate.minute) == false) {
@@ -229,6 +233,7 @@ class _CronIterator implements CronIterator<TZDateTime> {
 
   @override
   TZDateTime current() {
+    assert(_nextCalled || _previousCalled);
     return _currentDate;
   }
 }

--- a/lib/cron_parser.dart
+++ b/lib/cron_parser.dart
@@ -8,10 +8,14 @@ import 'package:timezone/timezone.dart';
 abstract class HasNext<E> {
   /// Find next suitable date
   E next();
+}
 
+abstract class HasPrevious<E> {
   /// Find previous suitable date
   E previous();
+}
 
+mixin CronIterator<E> on HasPrevious, HasNext {
   E current();
 }
 
@@ -25,7 +29,7 @@ abstract class Cron {
   /// It returns an iterator [HasNext] which delivers [TZDateTime] events. If no [startTime]
   /// is provided [TZDateTime.now(getLocation(locationName)] is used.
   /// The [locationName] string has to be in the format listed at http://www.iana.org/time-zones.
-  HasNext<TZDateTime> parse(String cronString, String locationName,
+  CronIterator<TZDateTime> parse(String cronString, String locationName,
       [TZDateTime? startTime]);
 }
 
@@ -49,7 +53,7 @@ final RegExp _cronRegex = RegExp(
 
 class _Cron implements Cron {
   @override
-  HasNext<TZDateTime> parse(String cronString, String locationName,
+  CronIterator<TZDateTime> parse(String cronString, String locationName,
       [TZDateTime? startTime]) {
     assert(cronString.isNotEmpty);
     assert(_cronRegex.hasMatch(cronString));
@@ -139,7 +143,7 @@ List<int>? _parseConstraint(dynamic constraint) {
   throw 'Unable to parse: $constraint';
 }
 
-class _CronIterator implements HasNext<TZDateTime> {
+class _CronIterator implements CronIterator<TZDateTime> {
   _Schedule _schedule;
   TZDateTime _currentDate;
 

--- a/lib/cron_parser.dart
+++ b/lib/cron_parser.dart
@@ -21,10 +21,10 @@ abstract class Cron {
     return _Cron();
   }
 
-  // Takes a [cronString], a [locationName] and an optional [startTime].
-  // It returns an iterator [HasNext] which delivers [TZDateTime] events. If no [startTime]
-  // is provided [TZDateTime.now(getLocation(locationName)] is used.
-  // The [locationName] string has to be in the format listed at http://www.iana.org/time-zones.
+  /// Takes a [cronString], a [locationName] and an optional [startTime].
+  /// It returns an iterator [HasNext] which delivers [TZDateTime] events. If no [startTime]
+  /// is provided [TZDateTime.now(getLocation(locationName)] is used.
+  /// The [locationName] string has to be in the format listed at http://www.iana.org/time-zones.
   HasNext<TZDateTime> parse(String cronString, String locationName,
       [TZDateTime? startTime]);
 }

--- a/lib/cron_parser.dart
+++ b/lib/cron_parser.dart
@@ -15,7 +15,7 @@ abstract class HasPrevious<E> {
   E previous();
 }
 
-mixin CronIterator<E> on HasPrevious, HasNext {
+mixin CronIterator<E> on HasPrevious<E>, HasNext<E> {
   E current();
 }
 

--- a/lib/cron_parser.dart
+++ b/lib/cron_parser.dart
@@ -6,7 +6,10 @@ import 'package:timezone/standalone.dart';
 import 'package:timezone/timezone.dart';
 
 abstract class HasNext<E> {
+  /// Find next suitable date
   E next();
+
+  /// Find previous suitable date
   E previous();
 
   E current();

--- a/lib/cron_parser.dart
+++ b/lib/cron_parser.dart
@@ -139,7 +139,6 @@ List<int>? _parseConstraint(dynamic constraint) {
 class _CronIterator implements HasNext<TZDateTime> {
   _Schedule _schedule;
   TZDateTime _currentDate;
-  bool _nextCalled = false;
 
   _CronIterator(this._schedule, this._currentDate) {
     _currentDate = TZDateTime.fromMillisecondsSinceEpoch(_currentDate.location,
@@ -148,7 +147,6 @@ class _CronIterator implements HasNext<TZDateTime> {
 
   @override
   TZDateTime next() {
-    _nextCalled = true;
     _currentDate = _currentDate.add(Duration(minutes: 1));
     while (true) {
       if (_schedule.months?.contains(_currentDate.month) == false) {
@@ -182,32 +180,40 @@ class _CronIterator implements HasNext<TZDateTime> {
 
   @override
   TZDateTime previous() {
-    _nextCalled = true;
     _currentDate = _currentDate.subtract(Duration(minutes: 1));
     while (true) {
-      if (_schedule.months?.contains(_currentDate.month) == false) {
-        _currentDate = TZDateTime(_currentDate.location, _currentDate.year,
-            _currentDate.month - 1, 1);
-        continue;
-      }
-      if (_schedule.weekdays?.contains(_currentDate.weekday) == false) {
-        _currentDate = TZDateTime(_currentDate.location, _currentDate.year,
-            _currentDate.month, _currentDate.day - 1);
-        continue;
-      }
-      if (_schedule.days?.contains(_currentDate.day) == false) {
-        _currentDate = TZDateTime(_currentDate.location, _currentDate.year,
-            _currentDate.month, _currentDate.day - 1);
+      if (_schedule.minutes?.contains(_currentDate.minute) == false) {
+        _currentDate = _currentDate.subtract(Duration(minutes: 1));
         continue;
       }
       if (_schedule.hours?.contains(_currentDate.hour) == false) {
         _currentDate = _currentDate.subtract(Duration(hours: 1));
-        _currentDate =
-            _currentDate.subtract(Duration(minutes: _currentDate.minute));
         continue;
       }
-      if (_schedule.minutes?.contains(_currentDate.minute) == false) {
-        _currentDate = _currentDate.subtract(Duration(minutes: 1));
+      if (_schedule.days?.contains(_currentDate.day) == false) {
+        _currentDate = _currentDate.subtract(Duration(days: 1));
+        continue;
+      }
+      if (_schedule.weekdays?.contains(_currentDate.weekday) == false) {
+        _currentDate = TZDateTime(
+          _currentDate.location,
+          _currentDate.year,
+          _currentDate.month,
+          _currentDate.day - 1,
+          _currentDate.hour,
+          _currentDate.minute,
+        );
+        continue;
+      }
+      if (_schedule.months?.contains(_currentDate.month) == false) {
+        _currentDate = TZDateTime(
+          _currentDate.location,
+          _currentDate.year,
+          _currentDate.month - 1,
+          _currentDate.day,
+          _currentDate.hour,
+          _currentDate.minute,
+        );
         continue;
       }
       return _currentDate;
@@ -216,7 +222,6 @@ class _CronIterator implements HasNext<TZDateTime> {
 
   @override
   TZDateTime current() {
-    assert(_nextCalled);
     return _currentDate;
   }
 }

--- a/lib/cron_parser.dart
+++ b/lib/cron_parser.dart
@@ -22,7 +22,7 @@ abstract class Cron {
   // is provided [TZDateTime.now(getLocation(locationName)] is used.
   // The [locationName] string has to be in the format listed at http://www.iana.org/time-zones.
   HasNext<TZDateTime> parse(String cronString, String locationName,
-      [TZDateTime startTime]);
+      [TZDateTime? startTime]);
 }
 
 const String _regex0to59 = "([1-5]?[0-9])";
@@ -46,10 +46,9 @@ final RegExp _cronRegex = RegExp(
 class _Cron implements Cron {
   @override
   HasNext<TZDateTime> parse(String cronString, String locationName,
-      [TZDateTime startTime]) {
+      [TZDateTime? startTime]) {
     assert(cronString.isNotEmpty);
     assert(_cronRegex.hasMatch(cronString));
-    assert(locationName != null);
     var location = getLocation(locationName);
     if (startTime == null) startTime = TZDateTime.now(location);
     startTime = TZDateTime.from(startTime, location);
@@ -57,7 +56,7 @@ class _Cron implements Cron {
   }
 
   _Schedule _parse(String cronString) {
-    List<List<int>> p =
+    List<List<int>?> p =
         cronString.split(RegExp('\\s+')).map(_parseConstraint).toList();
     _Schedule schedule = _Schedule(
         minutes: p[0], hours: p[1], days: p[2], months: p[3], weekdays: p[4]);
@@ -66,11 +65,11 @@ class _Cron implements Cron {
 }
 
 class _Schedule {
-  final List<int> minutes;
-  final List<int> hours;
-  final List<int> days;
-  final List<int> months;
-  final List<int> weekdays;
+  final List<int>? minutes;
+  final List<int>? hours;
+  final List<int>? days;
+  final List<int>? months;
+  final List<int>? weekdays;
 
   _Schedule._(this.minutes, this.hours, this.days, this.months, this.weekdays);
 
@@ -80,25 +79,25 @@ class _Schedule {
       dynamic days,
       dynamic months,
       dynamic weekdays}) {
-    List<int> parsedMinutes =
-        _parseConstraint(minutes)?.where((x) => x >= 0 && x <= 59)?.toList();
-    List<int> parsedHours =
-        _parseConstraint(hours)?.where((x) => x >= 0 && x <= 23)?.toList();
-    List<int> parsedDays =
-        _parseConstraint(days)?.where((x) => x >= 1 && x <= 31)?.toList();
-    List<int> parsedMonths =
-        _parseConstraint(months)?.where((x) => x >= 1 && x <= 12)?.toList();
-    List<int> parsedWeekdays = _parseConstraint(weekdays)
+    List<int>? parsedMinutes =
+        _parseConstraint(minutes)?.where((x) => x >= 0 && x <= 59).toList();
+    List<int>? parsedHours =
+        _parseConstraint(hours)?.where((x) => x >= 0 && x <= 23).toList();
+    List<int>? parsedDays =
+        _parseConstraint(days)?.where((x) => x >= 1 && x <= 31).toList();
+    List<int>? parsedMonths =
+        _parseConstraint(months)?.where((x) => x >= 1 && x <= 12).toList();
+    List<int>? parsedWeekdays = _parseConstraint(weekdays)
         ?.where((x) => x >= 0 && x <= 7)
-        ?.map((x) => x == 0 ? 7 : x)
-        ?.toSet()
-        ?.toList();
+        .map((x) => x == 0 ? 7 : x)
+        .toSet()
+        .toList();
     return _Schedule._(
         parsedMinutes, parsedHours, parsedDays, parsedMonths, parsedWeekdays);
   }
 }
 
-List<int> _parseConstraint(dynamic constraint) {
+List<int>? _parseConstraint(dynamic constraint) {
   if (constraint == null) return null;
   if (constraint is int) return [constraint];
   if (constraint is List<int>) return constraint;
@@ -107,12 +106,12 @@ List<int> _parseConstraint(dynamic constraint) {
     final parts = constraint.split(',');
     if (parts.length > 1) {
       final items =
-          parts.map(_parseConstraint).expand((list) => list).toSet().toList();
+          parts.map(_parseConstraint).expand((list) => list!).toSet().toList();
       items.sort();
       return items;
     }
 
-    int singleValue = int.tryParse(constraint);
+    int? singleValue = int.tryParse(constraint);
     if (singleValue != null) return [singleValue];
 
     if (constraint.startsWith('*/')) {
@@ -151,28 +150,28 @@ class _CronIterator implements HasNext<TZDateTime> {
     _nextCalled = true;
     _currentDate = _currentDate.add(Duration(minutes: 1));
     while (true) {
-      if (_schedule?.months?.contains(_currentDate.month) == false) {
+      if (_schedule.months?.contains(_currentDate.month) == false) {
         _currentDate = TZDateTime(_currentDate.location, _currentDate.year,
             _currentDate.month + 1, 1);
         continue;
       }
-      if (_schedule?.weekdays?.contains(_currentDate.weekday) == false) {
+      if (_schedule.weekdays?.contains(_currentDate.weekday) == false) {
         _currentDate = TZDateTime(_currentDate.location, _currentDate.year,
             _currentDate.month, _currentDate.day + 1);
         continue;
       }
-      if (_schedule?.days?.contains(_currentDate.day) == false) {
+      if (_schedule.days?.contains(_currentDate.day) == false) {
         _currentDate = TZDateTime(_currentDate.location, _currentDate.year,
             _currentDate.month, _currentDate.day + 1);
         continue;
       }
-      if (_schedule?.hours?.contains(_currentDate.hour) == false) {
+      if (_schedule.hours?.contains(_currentDate.hour) == false) {
         _currentDate = _currentDate.add(Duration(hours: 1));
         _currentDate =
             _currentDate.subtract(Duration(minutes: _currentDate.minute));
         continue;
       }
-      if (_schedule?.minutes?.contains(_currentDate.minute) == false) {
+      if (_schedule.minutes?.contains(_currentDate.minute) == false) {
         _currentDate = _currentDate.add(Duration(minutes: 1));
         continue;
       }

--- a/lib/cron_parser.dart
+++ b/lib/cron_parser.dart
@@ -7,6 +7,7 @@ import 'package:timezone/timezone.dart';
 
 abstract class HasNext<E> {
   E next();
+  E previous();
 
   E current();
 }
@@ -173,6 +174,40 @@ class _CronIterator implements HasNext<TZDateTime> {
       }
       if (_schedule.minutes?.contains(_currentDate.minute) == false) {
         _currentDate = _currentDate.add(Duration(minutes: 1));
+        continue;
+      }
+      return _currentDate;
+    }
+  }
+
+  @override
+  TZDateTime previous() {
+    _nextCalled = true;
+    _currentDate = _currentDate.subtract(Duration(minutes: 1));
+    while (true) {
+      if (_schedule.months?.contains(_currentDate.month) == false) {
+        _currentDate = TZDateTime(_currentDate.location, _currentDate.year,
+            _currentDate.month - 1, 1);
+        continue;
+      }
+      if (_schedule.weekdays?.contains(_currentDate.weekday) == false) {
+        _currentDate = TZDateTime(_currentDate.location, _currentDate.year,
+            _currentDate.month, _currentDate.day - 1);
+        continue;
+      }
+      if (_schedule.days?.contains(_currentDate.day) == false) {
+        _currentDate = TZDateTime(_currentDate.location, _currentDate.year,
+            _currentDate.month, _currentDate.day - 1);
+        continue;
+      }
+      if (_schedule.hours?.contains(_currentDate.hour) == false) {
+        _currentDate = _currentDate.subtract(Duration(hours: 1));
+        _currentDate =
+            _currentDate.subtract(Duration(minutes: _currentDate.minute));
+        continue;
+      }
+      if (_schedule.minutes?.contains(_currentDate.minute) == false) {
+        _currentDate = _currentDate.subtract(Duration(minutes: 1));
         continue;
       }
       return _currentDate;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/rbubke/cron-parser
 homepage: https://github.com/rbubke/cron-parser
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   timezone: ^0.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cron_parser
 description: A cron parser. Spits out next cron dates starting from now or a specific date.
-version: 0.4.0
+version: 0.5.0
 repository: https://github.com/rbubke/cron-parser
 homepage: https://github.com/rbubke/cron-parser
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cron_parser
 description: A cron parser. Spits out next cron dates starting from now or a specific date.
-version: 0.3.1
+version: 0.4.0
 repository: https://github.com/rbubke/cron-parser
 homepage: https://github.com/rbubke/cron-parser
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-  timezone: ^0.5.6
+  timezone: ^0.7.0
 
 dev_dependencies:
   test: ^1.14.2

--- a/test/cron_parser_test.dart
+++ b/test/cron_parser_test.dart
@@ -1025,7 +1025,7 @@ void main() {
 
   group('Smoke tests', () {
     group('.next()', () {
-      test('0 19 7 8 * (next)', () {
+      test('0 19 7 8 *', () {
         TZDateTime startDate =
             TZDateTime(getLocation("Europe/London"), 2021, 7, 12);
         var cronIterator =
@@ -1036,7 +1036,7 @@ void main() {
     });
 
     group('.previous()', () {
-      test('0 19 7 8 * (previous)', () {
+      test('0 19 7 8 *', () {
         TZDateTime startDate =
             TZDateTime(getLocation("Europe/London"), 2021, 7, 12);
         var cronIterator =

--- a/test/cron_parser_test.dart
+++ b/test/cron_parser_test.dart
@@ -5,999 +5,1045 @@ import 'package:timezone/timezone.dart';
 import '../lib/cron_parser.dart';
 
 void main() {
-  DateTime normalizedDate(
-      [DateTime? dateTime, String locationName = "Europe/Berlin"]) {
-    var location = getLocation(locationName);
-    TZDateTime date =
-        dateTime == null ? TZDateTime.now(location) : dateTime as TZDateTime;
-    return TZDateTime.from(
-        date.subtract(Duration(
-            microseconds: date.microsecond,
-            milliseconds: date.millisecond,
-            seconds: date.second)),
-        location);
-  }
-
-  test('Cron().parse() throws exception for invalid cron string', () {
-    expect(() => Cron().parse("", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("*", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("-1 * * * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("60 * * * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* -1 * * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* 24 * * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * 0 * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * 32 * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * * 0 *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * * 13 *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * * * -1", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * * * 8", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("-1-2 * * * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* -1-2 * * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * -1-2 * *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * * -1-2 *", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-    expect(() => Cron().parse("* * * * -1-2", "Europe/Berlin"),
-        throwsA(TypeMatcher<AssertionError>()));
-  });
-
-  group("Cron().parse() delivers", () {
-    test('correct locations', () {
-      TZDateTime date = normalizedDate() as TZDateTime;
-      var cronIterator = Cron().parse("* * * * *", "Africa/Gaborone");
-      expect(cronIterator.next().location.name, equals("Africa/Gaborone"));
-      expect(date.location.name, equals("Europe/Berlin"));
-      expect(date.add(Duration(minutes: 1)).location.name,
-          equals("Europe/Berlin"));
-    });
-
-    test('next minutes starting from date', () {
-      TZDateTime date = normalizedDate() as TZDateTime;
-      var cronIterator = Cron().parse("* * * * *", "Europe/Berlin");
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
-      expect(cronIterator.current(), equals(date.add(Duration(minutes: 1))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
-      expect(cronIterator.current(), equals(date.add(Duration(minutes: 2))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 3))));
-      expect(cronIterator.current(), equals(date.add(Duration(minutes: 3))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 4))));
-      expect(cronIterator.current(), equals(date.add(Duration(minutes: 4))));
-    });
-
-    test('previous minutes starting from date', () {
-      TZDateTime date = normalizedDate() as TZDateTime;
-      var cronIterator = Cron().parse("* * * * *", "Europe/Berlin");
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(minutes: 1))));
-      expect(
-          cronIterator.current(), equals(date.subtract(Duration(minutes: 1))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(minutes: 2))));
-      expect(
-          cronIterator.current(), equals(date.subtract(Duration(minutes: 2))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(minutes: 3))));
-      expect(
-          cronIterator.current(), equals(date.subtract(Duration(minutes: 3))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(minutes: 4))));
-      expect(
-          cronIterator.current(), equals(date.subtract(Duration(minutes: 4))));
-    });
-
-    test('next hours starting from date', () {
-      DateTime date = normalizedDate();
-      date = normalizedDate().subtract(Duration(minutes: date.minute));
-      var cronIterator = Cron().parse("0 * * * *", "Europe/Berlin");
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 3))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 4))));
-    });
-
-    test('previous hours starting from date', () {
-      DateTime date = normalizedDate();
-      date = normalizedDate().subtract(Duration(minutes: date.minute));
-      var cronIterator = Cron().parse("0 * * * *", "Europe/Berlin");
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 0))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 1))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 2))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 3))));
-    });
-
-    test('next days starting from date', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * *", "Europe/Berlin");
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(days: 1))));
-      expect(cronIterator.next(), equals(date.add(Duration(days: 2))));
-      expect(cronIterator.next(), equals(date.add(Duration(days: 3))));
-      expect(cronIterator.next(), equals(date.add(Duration(days: 4))));
-    });
-
-    test('previous days starting from date', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * *", "Europe/Berlin");
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.previous(), equals(date.subtract(Duration(days: 0))));
-      expect(cronIterator.previous(), equals(date.subtract(Duration(days: 1))));
-      expect(cronIterator.previous(), equals(date.subtract(Duration(days: 2))));
-      expect(cronIterator.previous(), equals(date.subtract(Duration(days: 3))));
-    });
-
-    test('next month starting from date', () {
-      DateTime date = normalizedDate();
-      var cronIterator = Cron().parse("0 0 1 * *", "Europe/Berlin");
-      expect(
-          cronIterator.next(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month + 1, 1)));
-      expect(
-          cronIterator.next(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month + 2, 1)));
-      expect(
-          cronIterator.next(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month + 3, 1)));
-      expect(
-          cronIterator.next(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month + 4, 1)));
-      expect(
-          cronIterator.next(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month + 5, 1)));
-    });
-
-    test('previous month starting from date', () {
-      DateTime date = normalizedDate();
-      var cronIterator = Cron().parse("0 0 1 * *", "Europe/Berlin");
-      expect(
-          cronIterator.previous(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month - 0, 1)));
-      expect(
-          cronIterator.previous(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month - 1, 1)));
-      expect(
-          cronIterator.previous(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month - 2, 1)));
-      expect(
-          cronIterator.previous(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month - 3, 1)));
-      expect(
-          cronIterator.previous(),
-          equals(TZDateTime(
-              getLocation("Europe/Berlin"), date.year, date.month - 4, 1)));
-    });
-
-    test('next weekday starting from monday', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 1", "Europe/Berlin");
-      var previous = cronIterator.next();
-      expect(previous.weekday, equals(1));
-      var next = cronIterator.next();
-      expect(next.weekday, equals(1));
-      expect(next, equals(previous.add(Duration(days: 7))));
-    });
-
-    test('previous weekday starting from monday', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 1", "Europe/Berlin");
-      var next = cronIterator.previous();
-      expect(next.weekday, equals(1));
-      var previous = cronIterator.previous();
-      expect(previous.weekday, equals(1));
-      expect(previous, equals(next.subtract(Duration(days: 7))));
-    });
-
-    test('next weekday starting from sunday', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 0", "Europe/Berlin");
-      var previous = cronIterator.next();
-      expect(previous.weekday, equals(7));
-      var next = cronIterator.next();
-      expect(next.weekday, equals(7));
-      expect(next, equals(previous.add(Duration(days: 7))));
-    });
-
-    test('previous weekday starting from sunday', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 0", "Europe/Berlin");
-      var next = cronIterator.previous();
-      expect(next.weekday, equals(7));
-      var previous = cronIterator.previous();
-      expect(previous.weekday, equals(7));
-      expect(previous, equals(next.subtract(Duration(days: 7))));
-    });
-
-    test('next weekday starting from sunday with 7', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 7", "Europe/Berlin");
-      var previous = cronIterator.next();
-      expect(previous.weekday, equals(7));
-      var next = cronIterator.next();
-      expect(next.weekday, equals(7));
-      expect(next, equals(previous.add(Duration(days: 7))));
-    });
-
-    test('previous weekday starting from sunday with 7', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 7", "Europe/Berlin");
-      var next = cronIterator.previous();
-      expect(next.weekday, equals(7));
-      var previous = cronIterator.previous();
-      expect(previous.weekday, equals(7));
-      expect(previous, equals(next.subtract(Duration(days: 7))));
-    });
-
-    test('next weekday starting from saturday', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 6", "Europe/Berlin");
-      var previous = cronIterator.next();
-      expect(previous.weekday, equals(6));
-      var next = cronIterator.next();
-      expect(next.weekday, equals(6));
-      expect(next, equals(previous.add(Duration(days: 7))));
-    });
-
-    test('previous weekday starting from saturday', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 6", "Europe/Berlin");
-      var next = cronIterator.previous();
-      expect(next.weekday, equals(6));
-      var previous = cronIterator.previous();
-      expect(previous.weekday, equals(6));
-      expect(previous, equals(next.subtract(Duration(days: 7))));
-    });
-
-    test('next weekday starting from friday', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 5", "Europe/Berlin");
-      var previous = cronIterator.next();
-      expect(previous.weekday, equals(5));
-      var next = cronIterator.next();
-      expect(next.weekday, equals(5));
-      expect(next, equals(previous.add(Duration(days: 7))));
-    });
-
-    test('previous weekday starting from friday', () {
-      DateTime date = normalizedDate();
-      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
-      var cronIterator = Cron().parse("0 0 * * 5", "Europe/Berlin");
-      var previous = cronIterator.previous();
-      expect(previous.weekday, equals(5));
-      var next = cronIterator.previous();
-      expect(next.weekday, equals(5));
-      expect(next, equals(previous.subtract(Duration(days: 7))));
-    });
-
-    test('next minutes range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator =
-          Cron().parse("0-3 * * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 3))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 60))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 61))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 62))));
-    });
-
-    test('previous minutes range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator =
-          Cron().parse("0-3 * * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 57))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 58))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 59))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 60))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 117))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 118))));
-    });
-
-    test('next minutes selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator =
-          Cron().parse("0,1,2,3 * * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 3))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 60))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 61))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 62))));
-    });
-
-    test('previous minutes selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator =
-          Cron().parse("0,1,2,3 * * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 57))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 58))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 59))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 60))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 117))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 118))));
-    });
-
-    test('next hours range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator =
-          Cron().parse("0 0-3 * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 3))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 24))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 25))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 26))));
-    });
-
-    test('previous hours range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator =
-          Cron().parse("0 0-3 * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 21))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 22))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 23))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 24))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 45))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 46))));
-    });
-
-    test('next hours selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator =
-          Cron().parse("0 0,1,2,3 * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 3))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 24))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 25))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 26))));
-    });
-
-    test('next hours selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator =
-          Cron().parse("0 0,1,2,3 * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 21))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 22))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 23))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 24))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 45))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 46))));
-    });
-
-    test('next days range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator =
-          Cron().parse("0 0 1-3 * *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 1)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 05, 1)));
-    });
-
-    test('previous days range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator =
-          Cron().parse("0 0 1-3 * *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 3)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 2)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 1)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 3)));
-    });
-
-    test('next days selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator =
-          Cron().parse("0 0 1,2,3 * *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 1)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 05, 1)));
-    });
-
-    test('previous days selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator =
-          Cron().parse("0 0 1,2,3 * *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 3)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 2)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 1)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 3)));
-    });
-
-    test('next month range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator =
-          Cron().parse("0 0 4 1-3 *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 01, 4)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 02, 4)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 03, 4)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2022, 01, 4)));
-    });
-
-    test('previous month range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator =
-          Cron().parse("0 0 4 1-3 *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 4)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 4)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 01, 4)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 03, 4)));
-    });
-
-    test('next month selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator =
-          Cron().parse("0 0 4 1,2,3 *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 01, 4)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 02, 4)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 03, 4)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2022, 01, 4)));
-    });
-
-    test('previous month selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator =
-          Cron().parse("0 0 4 1,2,3 *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 4)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 4)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 01, 4)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 03, 4)));
-    });
-
-    test('next weekdays range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 * * 0-5", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 5)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 6)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 7)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 8)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 9)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 10)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 12)));
-    });
-
-    test('previous weekdays range starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 * * 0-5", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 30)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 27)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 26)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 25)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 24)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 23)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 22)));
-    });
-
-    test('next weekdays selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron()
-          .parse("0 0 * * 0,1,2,3,4,5", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 5)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 6)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 7)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 8)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 9)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 10)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 12)));
-    });
-
-    test('previous weekdays selection starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron()
-          .parse("0 0 * * 0,1,2,3,4,5", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 30)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 27)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 26)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 25)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 24)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 23)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 22)));
-    });
-
-    test('next minutes interval starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("*/5 * * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 5))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 10))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 15))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 20))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 25))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 30))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 35))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 40))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 45))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 50))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 55))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 60))));
-      expect(cronIterator.next(), equals(date.add(Duration(minutes: 65))));
-    });
-
-    test('previous minutes interval starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("*/5 * * * *", "Europe/Berlin", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(minutes: 5))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 10))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 15))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 20))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 25))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 30))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 35))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 40))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 45))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 50))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 55))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 60))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(minutes: 65))));
-    });
-
-    test('next hours interval starting from date', () {
-      initializeTimeZone();
+  group('Cron().parse()', () {
+    DateTime normalizedDate(
+        [DateTime? dateTime, String locationName = "Europe/Berlin"]) {
+      var location = getLocation(locationName);
       TZDateTime date =
-          normalizedDate(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01))
+          dateTime == null ? TZDateTime.now(location) : dateTime as TZDateTime;
+      return TZDateTime.from(
+          date.subtract(Duration(
+              microseconds: date.microsecond,
+              milliseconds: date.millisecond,
+              seconds: date.second)),
+          location);
+    }
+
+    test('throws exception for invalid cron string', () {
+      expect(() => Cron().parse("", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("*", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("-1 * * * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("60 * * * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* -1 * * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* 24 * * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * 0 * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * 32 * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * * 0 *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * * 13 *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * * * -1", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * * * 8", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("-1-2 * * * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* -1-2 * * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * -1-2 * *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * * -1-2 *", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+      expect(() => Cron().parse("* * * * -1-2", "Europe/Berlin"),
+          throwsA(TypeMatcher<AssertionError>()));
+    });
+
+    group("delivers", () {
+      test('correct locations', () {
+        TZDateTime date = normalizedDate() as TZDateTime;
+        var cronIterator = Cron().parse("* * * * *", "Africa/Gaborone");
+        expect(cronIterator.next().location.name, equals("Africa/Gaborone"));
+        expect(date.location.name, equals("Europe/Berlin"));
+        expect(date.add(Duration(minutes: 1)).location.name,
+            equals("Europe/Berlin"));
+      });
+
+      group('next', () {
+        test('minutes starting from date', () {
+          TZDateTime date = normalizedDate() as TZDateTime;
+          var cronIterator = Cron().parse("* * * * *", "Europe/Berlin");
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
+          expect(
+              cronIterator.current(), equals(date.add(Duration(minutes: 1))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
+          expect(
+              cronIterator.current(), equals(date.add(Duration(minutes: 2))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 3))));
+          expect(
+              cronIterator.current(), equals(date.add(Duration(minutes: 3))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 4))));
+          expect(
+              cronIterator.current(), equals(date.add(Duration(minutes: 4))));
+        });
+
+        test('hours starting from date', () {
+          DateTime date = normalizedDate();
+          date = normalizedDate().subtract(Duration(minutes: date.minute));
+          var cronIterator = Cron().parse("0 * * * *", "Europe/Berlin");
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 3))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 4))));
+        });
+
+        test('days starting from date', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * *", "Europe/Berlin");
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(), equals(date.add(Duration(days: 1))));
+          expect(cronIterator.next(), equals(date.add(Duration(days: 2))));
+          expect(cronIterator.next(), equals(date.add(Duration(days: 3))));
+          expect(cronIterator.next(), equals(date.add(Duration(days: 4))));
+        });
+
+        test('month starting from date', () {
+          DateTime date = normalizedDate();
+          var cronIterator = Cron().parse("0 0 1 * *", "Europe/Berlin");
+          expect(
+              cronIterator.next(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month + 1, 1)));
+          expect(
+              cronIterator.next(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month + 2, 1)));
+          expect(
+              cronIterator.next(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month + 3, 1)));
+          expect(
+              cronIterator.next(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month + 4, 1)));
+          expect(
+              cronIterator.next(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month + 5, 1)));
+        });
+
+        test('weekday starting from monday', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 1", "Europe/Berlin");
+          var previous = cronIterator.next();
+          expect(previous.weekday, equals(1));
+          var next = cronIterator.next();
+          expect(next.weekday, equals(1));
+          expect(next, equals(previous.add(Duration(days: 7))));
+        });
+
+        test('weekday starting from sunday', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 0", "Europe/Berlin");
+          var previous = cronIterator.next();
+          expect(previous.weekday, equals(7));
+          var next = cronIterator.next();
+          expect(next.weekday, equals(7));
+          expect(next, equals(previous.add(Duration(days: 7))));
+        });
+
+        test('weekday starting from sunday with 7', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 7", "Europe/Berlin");
+          var previous = cronIterator.next();
+          expect(previous.weekday, equals(7));
+          var next = cronIterator.next();
+          expect(next.weekday, equals(7));
+          expect(next, equals(previous.add(Duration(days: 7))));
+        });
+
+        test('weekday starting from saturday', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 6", "Europe/Berlin");
+          var previous = cronIterator.next();
+          expect(previous.weekday, equals(6));
+          var next = cronIterator.next();
+          expect(next.weekday, equals(6));
+          expect(next, equals(previous.add(Duration(days: 7))));
+        });
+
+        test('weekday starting from friday', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 5", "Europe/Berlin");
+          var previous = cronIterator.next();
+          expect(previous.weekday, equals(5));
+          var next = cronIterator.next();
+          expect(next.weekday, equals(5));
+          expect(next, equals(previous.add(Duration(days: 7))));
+        });
+
+        test('minutes range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+          var cronIterator =
+              Cron().parse("0-3 * * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 3))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 60))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 61))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 62))));
+        });
+
+        test('minutes selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+          var cronIterator = Cron()
+              .parse("0,1,2,3 * * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 3))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 60))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 61))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 62))));
+        });
+
+        test('hours range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+          var cronIterator =
+              Cron().parse("0 0-3 * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 3))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 24))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 25))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 26))));
+        });
+
+        test('hours selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+          var cronIterator = Cron()
+              .parse("0 0,1,2,3 * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 3))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 24))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 25))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 26))));
+        });
+
+        test('hours selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+          var cronIterator = Cron()
+              .parse("0 0,1,2,3 * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 21))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 22))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 23))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 24))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 45))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 46))));
+        });
+
+        test('days range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+          var cronIterator =
+              Cron().parse("0 0 1-3 * *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 1)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 05, 1)));
+        });
+
+        test('days selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+          var cronIterator = Cron()
+              .parse("0 0 1,2,3 * *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 1)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 05, 1)));
+        });
+
+        test('month range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+          var cronIterator =
+              Cron().parse("0 0 4 1-3 *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 01, 4)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 02, 4)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 03, 4)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2022, 01, 4)));
+        });
+
+        test('month selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+          var cronIterator = Cron()
+              .parse("0 0 4 1,2,3 *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 01, 4)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 02, 4)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 03, 4)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2022, 01, 4)));
+        });
+
+        test('weekdays range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("0 0 * * 0-5", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 5)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 6)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 7)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 8)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 9)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 10)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 12)));
+        });
+
+        test('weekdays selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator = Cron().parse(
+              "0 0 * * 0,1,2,3,4,5", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 5)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 6)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 7)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 8)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 9)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 10)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 12)));
+        });
+
+        test('minutes interval starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("*/5 * * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 5))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 10))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 15))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 20))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 25))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 30))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 35))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 40))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 45))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 50))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 55))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 60))));
+          expect(cronIterator.next(), equals(date.add(Duration(minutes: 65))));
+        });
+
+        test('hours interval starting from date', () {
+          initializeTimeZone();
+          TZDateTime date = normalizedDate(
+                  TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01))
               as TZDateTime;
-      var cronIterator = Cron().parse("0 */2 * * *", "Europe/Berlin", date);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 4))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 6))));
-    });
+          var cronIterator = Cron().parse("0 */2 * * *", "Europe/Berlin", date);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 4))));
+          expect(cronIterator.next(), equals(date.add(Duration(hours: 6))));
+        });
 
-    test('previous hours interval starting from date', () {
-      initializeTimeZone();
-      TZDateTime date =
-          normalizedDate(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01))
+        test('days interval starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("0 0 */3 * *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 6)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 9)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 12)));
+        });
+
+        test('month interval starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("0 0 1 */2 *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 6, 1)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 8, 1)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 10, 1)));
+        });
+
+        test('weekdays interval starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("0 0 * * */2", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 2)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 4)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 5)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 7)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 9)));
+        });
+      });
+
+      group('previous', () {
+        test('minutes starting from date', () {
+          TZDateTime date = normalizedDate() as TZDateTime;
+          var cronIterator = Cron().parse("* * * * *", "Europe/Berlin");
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 1))));
+          expect(cronIterator.current(),
+              equals(date.subtract(Duration(minutes: 1))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 2))));
+          expect(cronIterator.current(),
+              equals(date.subtract(Duration(minutes: 2))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 3))));
+          expect(cronIterator.current(),
+              equals(date.subtract(Duration(minutes: 3))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 4))));
+          expect(cronIterator.current(),
+              equals(date.subtract(Duration(minutes: 4))));
+        });
+
+        test('hours starting from date', () {
+          DateTime date = normalizedDate();
+          date = normalizedDate().subtract(Duration(minutes: date.minute));
+          var cronIterator = Cron().parse("0 * * * *", "Europe/Berlin");
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 0))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 1))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 2))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 3))));
+        });
+
+        test('days starting from date', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * *", "Europe/Berlin");
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(days: 0))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(days: 1))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(days: 2))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(days: 3))));
+        });
+
+        test('month starting from date', () {
+          DateTime date = normalizedDate();
+          var cronIterator = Cron().parse("0 0 1 * *", "Europe/Berlin");
+          expect(
+              cronIterator.previous(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month - 0, 1)));
+          expect(
+              cronIterator.previous(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month - 1, 1)));
+          expect(
+              cronIterator.previous(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month - 2, 1)));
+          expect(
+              cronIterator.previous(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month - 3, 1)));
+          expect(
+              cronIterator.previous(),
+              equals(TZDateTime(
+                  getLocation("Europe/Berlin"), date.year, date.month - 4, 1)));
+        });
+
+        test('weekday starting from monday', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 1", "Europe/Berlin");
+          var next = cronIterator.previous();
+          expect(next.weekday, equals(1));
+          var previous = cronIterator.previous();
+          expect(previous.weekday, equals(1));
+          expect(previous, equals(next.subtract(Duration(days: 7))));
+        });
+
+        test('weekday starting from sunday', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 0", "Europe/Berlin");
+          var next = cronIterator.previous();
+          expect(next.weekday, equals(7));
+          var previous = cronIterator.previous();
+          expect(previous.weekday, equals(7));
+          expect(previous, equals(next.subtract(Duration(days: 7))));
+        });
+
+        test('weekday starting from sunday with 7', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 7", "Europe/Berlin");
+          var next = cronIterator.previous();
+          expect(next.weekday, equals(7));
+          var previous = cronIterator.previous();
+          expect(previous.weekday, equals(7));
+          expect(previous, equals(next.subtract(Duration(days: 7))));
+        });
+
+        test('weekday starting from saturday', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 6", "Europe/Berlin");
+          var next = cronIterator.previous();
+          expect(next.weekday, equals(6));
+          var previous = cronIterator.previous();
+          expect(previous.weekday, equals(6));
+          expect(previous, equals(next.subtract(Duration(days: 7))));
+        });
+
+        test('weekday starting from friday', () {
+          DateTime date = normalizedDate();
+          date =
+              date.subtract(Duration(minutes: date.minute, hours: date.hour));
+          var cronIterator = Cron().parse("0 0 * * 5", "Europe/Berlin");
+          var previous = cronIterator.previous();
+          expect(previous.weekday, equals(5));
+          var next = cronIterator.previous();
+          expect(next.weekday, equals(5));
+          expect(next, equals(previous.subtract(Duration(days: 7))));
+        });
+
+        test('minutes range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+          var cronIterator =
+              Cron().parse("0-3 * * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 57))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 58))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 59))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 60))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 117))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 118))));
+        });
+
+        test('minutes selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+          var cronIterator = Cron()
+              .parse("0,1,2,3 * * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 57))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 58))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 59))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 60))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 117))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 118))));
+        });
+
+        test('hours range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+          var cronIterator =
+              Cron().parse("0 0-3 * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 21))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 22))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 23))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 24))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 45))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 46))));
+        });
+
+        test('days range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+          var cronIterator =
+              Cron().parse("0 0 1-3 * *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 3)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 2)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 1)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 3)));
+        });
+
+        test('days selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+          var cronIterator = Cron()
+              .parse("0 0 1,2,3 * *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 3)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 2)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 1)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 3)));
+        });
+
+        test('month range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+          var cronIterator =
+              Cron().parse("0 0 4 1-3 *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 4)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 4)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 01, 4)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 03, 4)));
+        });
+
+        test('month selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+          var cronIterator = Cron()
+              .parse("0 0 4 1,2,3 *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 4)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 4)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 01, 4)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 03, 4)));
+        });
+
+        test('weekdays range starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("0 0 * * 0-5", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 30)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 27)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 26)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 25)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 24)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 23)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 22)));
+        });
+
+        test('weekdays selection starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator = Cron().parse(
+              "0 0 * * 0,1,2,3,4,5", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 30)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 27)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 26)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 25)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 24)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 23)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 22)));
+        });
+
+        test('minutes interval starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("*/5 * * * *", "Europe/Berlin", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 5))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 10))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 15))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 20))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 25))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 30))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 35))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 40))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 45))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 50))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 55))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 60))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(minutes: 65))));
+        });
+
+        test('hours interval starting from date', () {
+          initializeTimeZone();
+          TZDateTime date = normalizedDate(
+                  TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01))
               as TZDateTime;
-      var cronIterator = Cron().parse("0 */2 * * *", "Europe/Berlin", date);
-      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 2))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 4))));
-      expect(
-          cronIterator.previous(), equals(date.subtract(Duration(hours: 6))));
+          var cronIterator = Cron().parse("0 */2 * * *", "Europe/Berlin", date);
+          date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 2))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 4))));
+          expect(cronIterator.previous(),
+              equals(date.subtract(Duration(hours: 6))));
+        });
+
+        test('days interval starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("0 0 */3 * *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 30)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 27)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 24)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 21)));
+        });
+
+        test('month interval starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("0 0 1 */2 *", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 2, 1)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 12, 1)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 10, 1)));
+        });
+
+        test('weekdays interval starting from date', () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          var cronIterator =
+              Cron().parse("0 0 * * */2", "Europe/Berlin", date as TZDateTime);
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 31)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 29)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 28)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 26)));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 24)));
+        });
+      });
     });
 
-    test('next days interval starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 */3 * *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 6)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 9)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 12)));
+    group('handles timezone correctly', () {
+      test('when provided timezone is Europe/London (next)', () {
+        DateTime date = normalizedDate(
+            TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+        var cronIterator =
+            Cron().parse("0 0 * * *", "Europe/London", date as TZDateTime);
+        date = TZDateTime.from(date, getLocation("Europe/London"));
+        expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
+        expect(
+            cronIterator.next(), equals(date.add(Duration(days: 1, hours: 1))));
+        expect(
+            cronIterator.next(), equals(date.add(Duration(days: 2, hours: 1))));
+      });
+
+      test('when provided timezone is Europe/London (previous)', () {
+        DateTime date = normalizedDate(
+            TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+        var cronIterator =
+            Cron().parse("0 0 * * *", "Europe/London", date as TZDateTime);
+        date = TZDateTime.from(date, getLocation("Europe/London"));
+        expect(cronIterator.previous(),
+            equals(date.subtract(Duration(days: 1, hours: -1))));
+        expect(cronIterator.previous(),
+            equals(date.subtract(Duration(days: 2, hours: -1))));
+        expect(cronIterator.previous(),
+            equals(date.subtract(Duration(days: 3, hours: -2))));
+      });
+
+      test(
+          'when provided timezone is in the middle of DST change for America/New_York (next)',
+          () {
+        DateTime date = normalizedDate(
+            TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+        var cronIterator =
+            Cron().parse("0 19 * * *", "America/New_York", date as TZDateTime);
+        expect(
+            cronIterator.next(),
+            equals(
+                TZDateTime(getLocation("America/New_York"), 2020, 03, 31, 19)));
+        expect(
+            cronIterator.next(),
+            equals(
+                TZDateTime(getLocation("America/New_York"), 2020, 04, 01, 19)));
+        expect(
+            cronIterator.next(),
+            equals(
+                TZDateTime(getLocation("America/New_York"), 2020, 04, 02, 19)));
+        expect(
+            cronIterator.next(),
+            equals(
+                TZDateTime(getLocation("America/New_York"), 2020, 04, 03, 19)));
+      });
+
+      test(
+          'when provided timezone is in the middle of DST change for America/New_York (previous)',
+          () {
+        DateTime date = normalizedDate(
+            TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+        var cronIterator =
+            Cron().parse("0 19 * * *", "America/New_York", date as TZDateTime);
+        expect(
+            cronIterator.previous(),
+            equals(
+                TZDateTime(getLocation("America/New_York"), 2020, 03, 30, 19)));
+        expect(
+            cronIterator.previous(),
+            equals(
+                TZDateTime(getLocation("America/New_York"), 2020, 03, 29, 19)));
+        expect(
+            cronIterator.previous(),
+            equals(
+                TZDateTime(getLocation("America/New_York"), 2020, 03, 28, 19)));
+        expect(
+            cronIterator.previous(),
+            equals(
+                TZDateTime(getLocation("America/New_York"), 2020, 03, 27, 19)));
+      });
     });
 
-    test('previous days interval starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 */3 * *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 30)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 27)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 24)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 21)));
-    });
+    group('handles timezone DST changes correctly', () {
+      group('.next()', () {
+        test(
+            'when provided timezone is in the middle of DST change for Europe/London',
+            () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 1));
+          var cronIterator =
+              Cron().parse("0 * * * *", "Europe/London", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/London"));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 3)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 4)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 5)));
+        });
 
-    test('next month interval starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 1 */2 *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 6, 1)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 8, 1)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 10, 1)));
-    });
+        test('test', () {
+          TZDateTime startDate =
+              TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
+          var cronIterator =
+              Cron().parse("0 * * * *", "Europe/London", startDate);
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/London"), 2020, 4, 01, 1)));
+          expect(cronIterator.next(),
+              equals(TZDateTime(getLocation("Europe/London"), 2020, 4, 01, 2)));
+          print(cronIterator.next());
+        });
+      });
 
-    test('previous month interval starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 1 */2 *", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 2, 1)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 12, 1)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 10, 1)));
-    });
+      group('.previous()', () {
+        test(
+            'when provided timezone is in the middle of DST change for Europe/London',
+            () {
+          DateTime date = normalizedDate(
+              TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 1));
+          var cronIterator =
+              Cron().parse("0 * * * *", "Europe/London", date as TZDateTime);
+          date = TZDateTime.from(date, getLocation("Europe/London"));
+          expect(cronIterator.previous(),
+              equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 0)));
+          expect(
+              cronIterator.previous(),
+              equals(
+                  TZDateTime(getLocation("Europe/London"), 2020, 3, 28, 23)));
+          expect(
+              cronIterator.previous(),
+              equals(
+                  TZDateTime(getLocation("Europe/London"), 2020, 3, 28, 22)));
+        });
 
-    test('next weekdays interval starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 * * */2", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 2)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 4)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 5)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 7)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 9)));
-    });
-
-    test('previous weekdays interval starting from date', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 * * */2", "Europe/Berlin", date as TZDateTime);
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 31)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 29)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 28)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 26)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 24)));
-    });
-  });
-
-  group("Cron().parse() handles timezone correctly", () {
-    test('when provided timezone is Europe/London (next)', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 * * *", "Europe/London", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/London"));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
-      expect(
-          cronIterator.next(), equals(date.add(Duration(days: 1, hours: 1))));
-      expect(
-          cronIterator.next(), equals(date.add(Duration(days: 2, hours: 1))));
-    });
-
-    test('when provided timezone is Europe/London (previous)', () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 * * *", "Europe/London", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/London"));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(days: 1, hours: -1))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(days: 2, hours: -1))));
-      expect(cronIterator.previous(),
-          equals(date.subtract(Duration(days: 3, hours: -2))));
-    });
-
-    test(
-        'when provided timezone is in the middle of DST change for America/New_York (next)',
-        () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 19 * * *", "America/New_York", date as TZDateTime);
-      expect(
-          cronIterator.next(),
-          equals(
-              TZDateTime(getLocation("America/New_York"), 2020, 03, 31, 19)));
-      expect(
-          cronIterator.next(),
-          equals(
-              TZDateTime(getLocation("America/New_York"), 2020, 04, 01, 19)));
-      expect(
-          cronIterator.next(),
-          equals(
-              TZDateTime(getLocation("America/New_York"), 2020, 04, 02, 19)));
-      expect(
-          cronIterator.next(),
-          equals(
-              TZDateTime(getLocation("America/New_York"), 2020, 04, 03, 19)));
-    });
-
-    test(
-        'when provided timezone is in the middle of DST change for America/New_York (previous)',
-        () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 19 * * *", "America/New_York", date as TZDateTime);
-      expect(
-          cronIterator.previous(),
-          equals(
-              TZDateTime(getLocation("America/New_York"), 2020, 03, 30, 19)));
-      expect(
-          cronIterator.previous(),
-          equals(
-              TZDateTime(getLocation("America/New_York"), 2020, 03, 29, 19)));
-      expect(
-          cronIterator.previous(),
-          equals(
-              TZDateTime(getLocation("America/New_York"), 2020, 03, 28, 19)));
-      expect(
-          cronIterator.previous(),
-          equals(
-              TZDateTime(getLocation("America/New_York"), 2020, 03, 27, 19)));
-    });
-  });
-
-  group("Cron().parse() handles timezone DST changes correctly", () {
-    test(
-        'when provided timezone is in the middle of DST change for Europe/London (next)',
-        () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 1));
-      var cronIterator =
-          Cron().parse("0 * * * *", "Europe/London", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/London"));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 3)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 4)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 5)));
-    });
-
-    test(
-        'when provided timezone is in the middle of DST change for Europe/London (previous)',
-        () {
-      DateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 1));
-      var cronIterator =
-          Cron().parse("0 * * * *", "Europe/London", date as TZDateTime);
-      date = TZDateTime.from(date, getLocation("Europe/London"));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 0)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 28, 23)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 28, 22)));
-    });
-
-    test('test (next)', () {
-      TZDateTime startDate =
-          TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
-      var cronIterator = Cron().parse("0 * * * *", "Europe/London", startDate);
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 4, 01, 1)));
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 4, 01, 2)));
-      print(cronIterator.next());
-    });
-
-    test('test (previous)', () {
-      TZDateTime startDate =
-          TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
-      var cronIterator = Cron().parse("0 * * * *", "Europe/London", startDate);
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 31, 23)));
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 31, 22)));
-      print(cronIterator.previous());
+        test('test', () {
+          TZDateTime startDate =
+              TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
+          var cronIterator =
+              Cron().parse("0 * * * *", "Europe/London", startDate);
+          expect(
+              cronIterator.previous(),
+              equals(
+                  TZDateTime(getLocation("Europe/London"), 2020, 3, 31, 23)));
+          expect(
+              cronIterator.previous(),
+              equals(
+                  TZDateTime(getLocation("Europe/London"), 2020, 3, 31, 22)));
+          print(cronIterator.previous());
+        });
+      });
     });
   });
 
   group('Smoke tests', () {
-    test('0 19 7 8 * (previous)', () {
-      TZDateTime startDate =
-          TZDateTime(getLocation("Europe/London"), 2021, 7, 12);
-      var cronIterator = Cron().parse("0 19 7 8 *", "Europe/London", startDate);
-      expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/London"), 2020, 8, 7, 19)));
+    group('.next()', () {
+      test('0 19 7 8 * (next)', () {
+        TZDateTime startDate =
+            TZDateTime(getLocation("Europe/London"), 2021, 7, 12);
+        var cronIterator =
+            Cron().parse("0 19 7 8 *", "Europe/London", startDate);
+        expect(cronIterator.next(),
+            equals(TZDateTime(getLocation("Europe/London"), 2021, 8, 7, 19)));
+      });
     });
 
-    test('0 19 7 8 * (next)', () {
-      TZDateTime startDate =
-          TZDateTime(getLocation("Europe/London"), 2021, 7, 12);
-      var cronIterator = Cron().parse("0 19 7 8 *", "Europe/London", startDate);
-      expect(cronIterator.next(),
-          equals(TZDateTime(getLocation("Europe/London"), 2021, 8, 7, 19)));
+    group('.previous()', () {
+      test('0 19 7 8 * (previous)', () {
+        TZDateTime startDate =
+            TZDateTime(getLocation("Europe/London"), 2021, 7, 12);
+        var cronIterator =
+            Cron().parse("0 19 7 8 *", "Europe/London", startDate);
+        expect(cronIterator.previous(),
+            equals(TZDateTime(getLocation("Europe/London"), 2020, 8, 7, 19)));
+      });
     });
   });
 }

--- a/test/cron_parser_test.dart
+++ b/test/cron_parser_test.dart
@@ -8,7 +8,8 @@ void main() {
   DateTime normalizedDate(
       [DateTime? dateTime, String locationName = "Europe/Berlin"]) {
     var location = getLocation(locationName);
-    TZDateTime date = dateTime == null ? TZDateTime.now(location) : dateTime as TZDateTime;
+    TZDateTime date =
+        dateTime == null ? TZDateTime.now(location) : dateTime as TZDateTime;
     return TZDateTime.from(
         date.subtract(Duration(
             microseconds: date.microsecond,
@@ -92,6 +93,28 @@ void main() {
       expect(cronIterator.current(), equals(date.add(Duration(minutes: 4))));
     });
 
+    test('previous minutes starting from date', () {
+      TZDateTime date = normalizedDate() as TZDateTime;
+      var cronIterator = Cron().parse("* * * * *", "Europe/Berlin");
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(minutes: 1))));
+      expect(
+          cronIterator.current(), equals(date.subtract(Duration(minutes: 1))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(minutes: 2))));
+      expect(
+          cronIterator.current(), equals(date.subtract(Duration(minutes: 2))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(minutes: 3))));
+      expect(
+          cronIterator.current(), equals(date.subtract(Duration(minutes: 3))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(minutes: 4))));
+      expect(
+          cronIterator.current(), equals(date.subtract(Duration(minutes: 4))));
+    });
+
     test('next hours starting from date', () {
       DateTime date = normalizedDate();
       date = normalizedDate().subtract(Duration(minutes: date.minute));
@@ -103,6 +126,21 @@ void main() {
       expect(cronIterator.next(), equals(date.add(Duration(hours: 4))));
     });
 
+    test('previous hours starting from date', () {
+      DateTime date = normalizedDate();
+      date = normalizedDate().subtract(Duration(minutes: date.minute));
+      var cronIterator = Cron().parse("0 * * * *", "Europe/Berlin");
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 0))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 1))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 2))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 3))));
+    });
+
     test('next days starting from date', () {
       DateTime date = normalizedDate();
       date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
@@ -112,6 +150,17 @@ void main() {
       expect(cronIterator.next(), equals(date.add(Duration(days: 2))));
       expect(cronIterator.next(), equals(date.add(Duration(days: 3))));
       expect(cronIterator.next(), equals(date.add(Duration(days: 4))));
+    });
+
+    test('previous days starting from date', () {
+      DateTime date = normalizedDate();
+      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
+      var cronIterator = Cron().parse("0 0 * * *", "Europe/Berlin");
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(cronIterator.previous(), equals(date.subtract(Duration(days: 0))));
+      expect(cronIterator.previous(), equals(date.subtract(Duration(days: 1))));
+      expect(cronIterator.previous(), equals(date.subtract(Duration(days: 2))));
+      expect(cronIterator.previous(), equals(date.subtract(Duration(days: 3))));
     });
 
     test('next month starting from date', () {
@@ -139,6 +188,31 @@ void main() {
               getLocation("Europe/Berlin"), date.year, date.month + 5, 1)));
     });
 
+    test('previous month starting from date', () {
+      DateTime date = normalizedDate();
+      var cronIterator = Cron().parse("0 0 1 * *", "Europe/Berlin");
+      expect(
+          cronIterator.previous(),
+          equals(TZDateTime(
+              getLocation("Europe/Berlin"), date.year, date.month - 0, 1)));
+      expect(
+          cronIterator.previous(),
+          equals(TZDateTime(
+              getLocation("Europe/Berlin"), date.year, date.month - 1, 1)));
+      expect(
+          cronIterator.previous(),
+          equals(TZDateTime(
+              getLocation("Europe/Berlin"), date.year, date.month - 2, 1)));
+      expect(
+          cronIterator.previous(),
+          equals(TZDateTime(
+              getLocation("Europe/Berlin"), date.year, date.month - 3, 1)));
+      expect(
+          cronIterator.previous(),
+          equals(TZDateTime(
+              getLocation("Europe/Berlin"), date.year, date.month - 4, 1)));
+    });
+
     test('next weekday starting from monday', () {
       DateTime date = normalizedDate();
       date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
@@ -148,6 +222,17 @@ void main() {
       var next = cronIterator.next();
       expect(next.weekday, equals(1));
       expect(next, equals(previous.add(Duration(days: 7))));
+    });
+
+    test('previous weekday starting from monday', () {
+      DateTime date = normalizedDate();
+      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
+      var cronIterator = Cron().parse("0 0 * * 1", "Europe/Berlin");
+      var next = cronIterator.previous();
+      expect(next.weekday, equals(1));
+      var previous = cronIterator.previous();
+      expect(previous.weekday, equals(1));
+      expect(previous, equals(next.subtract(Duration(days: 7))));
     });
 
     test('next weekday starting from sunday', () {
@@ -161,6 +246,17 @@ void main() {
       expect(next, equals(previous.add(Duration(days: 7))));
     });
 
+    test('previous weekday starting from sunday', () {
+      DateTime date = normalizedDate();
+      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
+      var cronIterator = Cron().parse("0 0 * * 0", "Europe/Berlin");
+      var next = cronIterator.previous();
+      expect(next.weekday, equals(7));
+      var previous = cronIterator.previous();
+      expect(previous.weekday, equals(7));
+      expect(previous, equals(next.subtract(Duration(days: 7))));
+    });
+
     test('next weekday starting from sunday with 7', () {
       DateTime date = normalizedDate();
       date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
@@ -170,6 +266,17 @@ void main() {
       var next = cronIterator.next();
       expect(next.weekday, equals(7));
       expect(next, equals(previous.add(Duration(days: 7))));
+    });
+
+    test('previous weekday starting from sunday with 7', () {
+      DateTime date = normalizedDate();
+      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
+      var cronIterator = Cron().parse("0 0 * * 7", "Europe/Berlin");
+      var next = cronIterator.previous();
+      expect(next.weekday, equals(7));
+      var previous = cronIterator.previous();
+      expect(previous.weekday, equals(7));
+      expect(previous, equals(next.subtract(Duration(days: 7))));
     });
 
     test('next weekday starting from saturday', () {
@@ -183,6 +290,17 @@ void main() {
       expect(next, equals(previous.add(Duration(days: 7))));
     });
 
+    test('previous weekday starting from saturday', () {
+      DateTime date = normalizedDate();
+      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
+      var cronIterator = Cron().parse("0 0 * * 6", "Europe/Berlin");
+      var next = cronIterator.previous();
+      expect(next.weekday, equals(6));
+      var previous = cronIterator.previous();
+      expect(previous.weekday, equals(6));
+      expect(previous, equals(next.subtract(Duration(days: 7))));
+    });
+
     test('next weekday starting from friday', () {
       DateTime date = normalizedDate();
       date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
@@ -194,10 +312,22 @@ void main() {
       expect(next, equals(previous.add(Duration(days: 7))));
     });
 
+    test('previous weekday starting from friday', () {
+      DateTime date = normalizedDate();
+      date = date.subtract(Duration(minutes: date.minute, hours: date.hour));
+      var cronIterator = Cron().parse("0 0 * * 5", "Europe/Berlin");
+      var previous = cronIterator.previous();
+      expect(previous.weekday, equals(5));
+      var next = cronIterator.previous();
+      expect(next.weekday, equals(5));
+      expect(next, equals(previous.subtract(Duration(days: 7))));
+    });
+
     test('next minutes range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator = Cron().parse("0-3 * * * *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0-3 * * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
@@ -205,12 +335,33 @@ void main() {
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 60))));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 61))));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 62))));
+    });
+
+    test('previous minutes range starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+      var cronIterator =
+          Cron().parse("0-3 * * * *", "Europe/Berlin", date as TZDateTime);
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 57))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 58))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 59))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 60))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 117))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 118))));
     });
 
     test('next minutes selection starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator = Cron().parse("0,1,2,3 * * * *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0,1,2,3 * * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
@@ -220,10 +371,65 @@ void main() {
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 62))));
     });
 
+    test('previous minutes selection starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+      var cronIterator =
+          Cron().parse("0,1,2,3 * * * *", "Europe/Berlin", date as TZDateTime);
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 57))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 58))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 59))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 60))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 117))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 118))));
+    });
+
     test('next hours range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator = Cron().parse("0 0-3 * * *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0-3 * * *", "Europe/Berlin", date as TZDateTime);
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
+      expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
+      expect(cronIterator.next(), equals(date.add(Duration(hours: 3))));
+      expect(cronIterator.next(), equals(date.add(Duration(hours: 24))));
+      expect(cronIterator.next(), equals(date.add(Duration(hours: 25))));
+      expect(cronIterator.next(), equals(date.add(Duration(hours: 26))));
+    });
+
+    test('previous hours range starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+      var cronIterator =
+          Cron().parse("0 0-3 * * *", "Europe/Berlin", date as TZDateTime);
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 21))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 22))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 23))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 24))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 45))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 46))));
+    });
+
+    test('next hours selection starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
+      var cronIterator =
+          Cron().parse("0 0,1,2,3 * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
@@ -236,20 +442,28 @@ void main() {
     test('next hours selection starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator = Cron().parse("0 0,1,2,3 * * *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0,1,2,3 * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 3))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 24))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 25))));
-      expect(cronIterator.next(), equals(date.add(Duration(hours: 26))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 21))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 22))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 23))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 24))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 45))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 46))));
     });
 
     test('next days range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator = Cron().parse("0 0 1-3 * *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0 1-3 * *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 1)));
       expect(cronIterator.next(),
@@ -258,12 +472,28 @@ void main() {
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 05, 1)));
+    });
+
+    test('previous days range starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+      var cronIterator =
+          Cron().parse("0 0 1-3 * *", "Europe/Berlin", date as TZDateTime);
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 3)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 2)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 1)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 3)));
     });
 
     test('next days selection starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator = Cron().parse("0 0 1,2,3 * *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0 1,2,3 * *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 1)));
       expect(cronIterator.next(),
@@ -274,10 +504,26 @@ void main() {
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 05, 1)));
     });
 
+    test('previous days selection starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+      var cronIterator =
+          Cron().parse("0 0 1,2,3 * *", "Europe/Berlin", date as TZDateTime);
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 3)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 2)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 1)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 3)));
+    });
+
     test('next month range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator = Cron().parse("0 0 4 1-3 *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0 4 1-3 *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 01, 4)));
       expect(cronIterator.next(),
@@ -286,12 +532,28 @@ void main() {
           equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 03, 4)));
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2022, 01, 4)));
+    });
+
+    test('previous month range starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+      var cronIterator =
+          Cron().parse("0 0 4 1-3 *", "Europe/Berlin", date as TZDateTime);
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 4)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 4)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 01, 4)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 02, 4)));
     });
 
     test('next month selection starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator = Cron().parse("0 0 4 1,2,3 *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0 4 1,2,3 *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 01, 4)));
       expect(cronIterator.next(),
@@ -302,10 +564,26 @@ void main() {
           equals(TZDateTime(getLocation("Europe/Berlin"), 2022, 01, 4)));
     });
 
+    test('previous month selection starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
+      var cronIterator =
+          Cron().parse("0 0 4 1,2,3 *", "Europe/Berlin", date as TZDateTime);
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 4)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 02, 4)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 01, 4)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 02, 4)));
+    });
+
     test('next weekdays range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 * * 0-5", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0 * * 0-5", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
@@ -325,13 +603,39 @@ void main() {
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 10)));
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 12)));
+    });
+
+    test('previous weekdays range starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+      var cronIterator =
+          Cron().parse("0 0 * * 0-5", "Europe/Berlin", date as TZDateTime);
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 30)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 27)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 26)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 25)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 24)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 23)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 22)));
     });
 
     test('next weekdays selection starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator =
-          Cron().parse("0 0 * * 0,1,2,3,4,5", "Europe/Berlin", date as TZDateTime);
+      var cronIterator = Cron()
+          .parse("0 0 * * 0,1,2,3,4,5", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
@@ -353,10 +657,37 @@ void main() {
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 12)));
     });
 
+    test('previous weekdays selection starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+      var cronIterator = Cron()
+          .parse("0 0 * * 0,1,2,3,4,5", "Europe/Berlin", date as TZDateTime);
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 30)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 27)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 26)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 25)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 24)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 23)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 22)));
+    });
+
     test('next minutes interval starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("*/5 * * * *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("*/5 * * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 5))));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 10))));
@@ -373,10 +704,45 @@ void main() {
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 65))));
     });
 
+    test('previous minutes interval starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+      var cronIterator =
+          Cron().parse("*/5 * * * *", "Europe/Berlin", date as TZDateTime);
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(minutes: 5))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 10))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 15))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 20))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 25))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 30))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 35))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 40))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 45))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 50))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 55))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 60))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(minutes: 65))));
+    });
+
     test('next hours interval starting from date', () {
       initializeTimeZone();
-      TZDateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01)) as TZDateTime;
+      TZDateTime date =
+          normalizedDate(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01))
+              as TZDateTime;
       var cronIterator = Cron().parse("0 */2 * * *", "Europe/Berlin", date);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
@@ -384,10 +750,26 @@ void main() {
       expect(cronIterator.next(), equals(date.add(Duration(hours: 6))));
     });
 
+    test('previous hours interval starting from date', () {
+      initializeTimeZone();
+      TZDateTime date =
+          normalizedDate(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01))
+              as TZDateTime;
+      var cronIterator = Cron().parse("0 */2 * * *", "Europe/Berlin", date);
+      date = TZDateTime.from(date, getLocation("Europe/Berlin"));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 2))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 4))));
+      expect(
+          cronIterator.previous(), equals(date.subtract(Duration(hours: 6))));
+    });
+
     test('next days interval starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 */3 * *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0 */3 * *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
       expect(cronIterator.next(),
@@ -398,10 +780,26 @@ void main() {
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 12)));
     });
 
+    test('previous days interval starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+      var cronIterator =
+          Cron().parse("0 0 */3 * *", "Europe/Berlin", date as TZDateTime);
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 30)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 27)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 24)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 21)));
+    });
+
     test('next month interval starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 1 */2 *", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0 1 */2 *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 6, 1)));
       expect(cronIterator.next(),
@@ -410,10 +808,24 @@ void main() {
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 10, 1)));
     });
 
+    test('previous month interval starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+      var cronIterator =
+          Cron().parse("0 0 1 */2 *", "Europe/Berlin", date as TZDateTime);
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 2, 1)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 12, 1)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 10, 1)));
+    });
+
     test('next weekdays interval starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 * * */2", "Europe/Berlin", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0 * * */2", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 2)));
       expect(cronIterator.next(),
@@ -425,13 +837,31 @@ void main() {
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 9)));
     });
+
+    test('previous weekdays interval starting from date', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+      var cronIterator =
+          Cron().parse("0 0 * * */2", "Europe/Berlin", date as TZDateTime);
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 31)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 29)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 28)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 26)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 3, 24)));
+    });
   });
 
   group("Cron().parse() handles timezone correctly", () {
-    test('when provided timezone is Europe/London', () {
+    test('when provided timezone is Europe/London (next)', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 * * *", "Europe/London", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 0 * * *", "Europe/London", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/London"));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
       expect(
@@ -439,12 +869,28 @@ void main() {
       expect(
           cronIterator.next(), equals(date.add(Duration(days: 2, hours: 1))));
     });
+
+    test('when provided timezone is Europe/London (previous)', () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+      var cronIterator =
+          Cron().parse("0 0 * * *", "Europe/London", date as TZDateTime);
+      date = TZDateTime.from(date, getLocation("Europe/London"));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(days: 1, hours: -1))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(days: 2, hours: -1))));
+      expect(cronIterator.previous(),
+          equals(date.subtract(Duration(days: 3, hours: -2))));
+    });
+
     test(
-        'when provided timezone is in the middle of DST change for America/New_York',
+        'when provided timezone is in the middle of DST change for America/New_York (next)',
         () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 19 * * *", "America/New_York", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 19 * * *", "America/New_York", date as TZDateTime);
       expect(
           cronIterator.next(),
           equals(
@@ -462,15 +908,41 @@ void main() {
           equals(
               TZDateTime(getLocation("America/New_York"), 2020, 04, 03, 19)));
     });
+
+    test(
+        'when provided timezone is in the middle of DST change for America/New_York (previous)',
+        () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+      var cronIterator =
+          Cron().parse("0 19 * * *", "America/New_York", date as TZDateTime);
+      expect(
+          cronIterator.previous(),
+          equals(
+              TZDateTime(getLocation("America/New_York"), 2020, 03, 30, 19)));
+      expect(
+          cronIterator.previous(),
+          equals(
+              TZDateTime(getLocation("America/New_York"), 2020, 03, 29, 19)));
+      expect(
+          cronIterator.previous(),
+          equals(
+              TZDateTime(getLocation("America/New_York"), 2020, 03, 28, 19)));
+      expect(
+          cronIterator.previous(),
+          equals(
+              TZDateTime(getLocation("America/New_York"), 2020, 03, 27, 19)));
+    });
   });
 
   group("Cron().parse() handles timezone DST changes correctly", () {
     test(
-        'when provided timezone is in the middle of DST change for Europe/London',
+        'when provided timezone is in the middle of DST change for Europe/London (next)',
         () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 1));
-      var cronIterator = Cron().parse("0 * * * *", "Europe/London", date as TZDateTime);
+      var cronIterator =
+          Cron().parse("0 * * * *", "Europe/London", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/London"));
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 3)));
@@ -480,7 +952,23 @@ void main() {
           equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 5)));
     });
 
-    test('test', () {
+    test(
+        'when provided timezone is in the middle of DST change for Europe/London (previous)',
+        () {
+      DateTime date = normalizedDate(
+          TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 1));
+      var cronIterator =
+          Cron().parse("0 * * * *", "Europe/London", date as TZDateTime);
+      date = TZDateTime.from(date, getLocation("Europe/London"));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 0)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 28, 23)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 28, 22)));
+    });
+
+    test('test (next)', () {
       TZDateTime startDate =
           TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
       var cronIterator = Cron().parse("0 * * * *", "Europe/London", startDate);
@@ -489,6 +977,17 @@ void main() {
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/London"), 2020, 4, 01, 2)));
       print(cronIterator.next());
+    });
+
+    test('test (previous)', () {
+      TZDateTime startDate =
+          TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
+      var cronIterator = Cron().parse("0 * * * *", "Europe/London", startDate);
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 31, 23)));
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 31, 22)));
+      print(cronIterator.previous());
     });
   });
 }

--- a/test/cron_parser_test.dart
+++ b/test/cron_parser_test.dart
@@ -6,9 +6,9 @@ import '../lib/cron_parser.dart';
 
 void main() {
   DateTime normalizedDate(
-      [DateTime dateTime, String locationName = "Europe/Berlin"]) {
+      [DateTime? dateTime, String locationName = "Europe/Berlin"]) {
     var location = getLocation(locationName);
-    TZDateTime date = dateTime == null ? TZDateTime.now(location) : dateTime;
+    TZDateTime date = dateTime == null ? TZDateTime.now(location) : dateTime as TZDateTime;
     return TZDateTime.from(
         date.subtract(Duration(
             microseconds: date.microsecond,
@@ -70,7 +70,7 @@ void main() {
 
   group("Cron().parse() delivers", () {
     test('correct locations', () {
-      TZDateTime date = normalizedDate();
+      TZDateTime date = normalizedDate() as TZDateTime;
       var cronIterator = Cron().parse("* * * * *", "Africa/Gaborone");
       expect(cronIterator.next().location.name, equals("Africa/Gaborone"));
       expect(date.location.name, equals("Europe/Berlin"));
@@ -79,7 +79,7 @@ void main() {
     });
 
     test('next minutes starting from date', () {
-      TZDateTime date = normalizedDate();
+      TZDateTime date = normalizedDate() as TZDateTime;
       var cronIterator = Cron().parse("* * * * *", "Europe/Berlin");
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
@@ -197,7 +197,7 @@ void main() {
     test('next minutes range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator = Cron().parse("0-3 * * * *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0-3 * * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
@@ -210,7 +210,7 @@ void main() {
     test('next minutes selection starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator = Cron().parse("0,1,2,3 * * * *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0,1,2,3 * * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 1))));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 2))));
@@ -223,7 +223,7 @@ void main() {
     test('next hours range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator = Cron().parse("0 0-3 * * *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0-3 * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
@@ -236,7 +236,7 @@ void main() {
     test('next hours selection starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 31));
-      var cronIterator = Cron().parse("0 0,1,2,3 * * *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0,1,2,3 * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
@@ -249,7 +249,7 @@ void main() {
     test('next days range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator = Cron().parse("0 0 1-3 * *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0 1-3 * *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 1)));
       expect(cronIterator.next(),
@@ -263,7 +263,7 @@ void main() {
     test('next days selection starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator = Cron().parse("0 0 1,2,3 * *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0 1,2,3 * *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 1)));
       expect(cronIterator.next(),
@@ -277,7 +277,7 @@ void main() {
     test('next month range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator = Cron().parse("0 0 4 1-3 *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0 4 1-3 *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 01, 4)));
       expect(cronIterator.next(),
@@ -291,7 +291,7 @@ void main() {
     test('next month selection starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 03, 29));
-      var cronIterator = Cron().parse("0 0 4 1,2,3 *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0 4 1,2,3 *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2021, 01, 4)));
       expect(cronIterator.next(),
@@ -305,7 +305,7 @@ void main() {
     test('next weekdays range starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 * * 0-5", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0 * * 0-5", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
@@ -331,7 +331,7 @@ void main() {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
       var cronIterator =
-          Cron().parse("0 0 * * 0,1,2,3,4,5", "Europe/Berlin", date);
+          Cron().parse("0 0 * * 0,1,2,3,4,5", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 2)));
@@ -356,7 +356,7 @@ void main() {
     test('next minutes interval starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("*/5 * * * *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("*/5 * * * *", "Europe/Berlin", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 5))));
       expect(cronIterator.next(), equals(date.add(Duration(minutes: 10))));
@@ -376,7 +376,7 @@ void main() {
     test('next hours interval starting from date', () {
       initializeTimeZone();
       TZDateTime date = normalizedDate(
-          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
+          TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01)) as TZDateTime;
       var cronIterator = Cron().parse("0 */2 * * *", "Europe/Berlin", date);
       date = TZDateTime.from(date, getLocation("Europe/Berlin"));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 2))));
@@ -387,7 +387,7 @@ void main() {
     test('next days interval starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 */3 * *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0 */3 * *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 3)));
       expect(cronIterator.next(),
@@ -401,7 +401,7 @@ void main() {
     test('next month interval starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 1 */2 *", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0 1 */2 *", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 6, 1)));
       expect(cronIterator.next(),
@@ -413,7 +413,7 @@ void main() {
     test('next weekdays interval starting from date', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 * * */2", "Europe/Berlin", date);
+      var cronIterator = Cron().parse("0 0 * * */2", "Europe/Berlin", date as TZDateTime);
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 4, 2)));
       expect(cronIterator.next(),
@@ -431,7 +431,7 @@ void main() {
     test('when provided timezone is Europe/London', () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 0 * * *", "Europe/London", date);
+      var cronIterator = Cron().parse("0 0 * * *", "Europe/London", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/London"));
       expect(cronIterator.next(), equals(date.add(Duration(hours: 1))));
       expect(
@@ -444,7 +444,7 @@ void main() {
         () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/Berlin"), 2020, 04, 01));
-      var cronIterator = Cron().parse("0 19 * * *", "America/New_York", date);
+      var cronIterator = Cron().parse("0 19 * * *", "America/New_York", date as TZDateTime);
       expect(
           cronIterator.next(),
           equals(
@@ -470,7 +470,7 @@ void main() {
         () {
       DateTime date = normalizedDate(
           TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 1));
-      var cronIterator = Cron().parse("0 * * * *", "Europe/London", date);
+      var cronIterator = Cron().parse("0 * * * *", "Europe/London", date as TZDateTime);
       date = TZDateTime.from(date, getLocation("Europe/London"));
       expect(cronIterator.next(),
           equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 29, 3)));

--- a/test/cron_parser_test.dart
+++ b/test/cron_parser_test.dart
@@ -1033,6 +1033,15 @@ void main() {
         expect(cronIterator.next(),
             equals(TZDateTime(getLocation("Europe/London"), 2021, 8, 7, 19)));
       });
+
+      test('0 11 * * *', () {
+        TZDateTime startDate =
+            TZDateTime(getLocation("Europe/London"), 2019, 11, 23, 12);
+        var cronIterator =
+            Cron().parse("0 11 * * *", "Europe/London", startDate);
+        expect(cronIterator.next(),
+            equals(TZDateTime(getLocation("Europe/London"), 2019, 11, 24, 11)));
+      });
     });
 
     group('.previous()', () {
@@ -1043,6 +1052,15 @@ void main() {
             Cron().parse("0 19 7 8 *", "Europe/London", startDate);
         expect(cronIterator.previous(),
             equals(TZDateTime(getLocation("Europe/London"), 2020, 8, 7, 19)));
+      });
+
+      test('0 11 * * *', () {
+        TZDateTime startDate =
+            TZDateTime(getLocation("Europe/London"), 2019, 11, 23, 12);
+        var cronIterator =
+            Cron().parse("0 11 * * *", "Europe/London", startDate);
+        expect(cronIterator.previous(),
+            equals(TZDateTime(getLocation("Europe/London"), 2019, 11, 23, 11)));
       });
     });
   });

--- a/test/cron_parser_test.dart
+++ b/test/cron_parser_test.dart
@@ -62,6 +62,14 @@ void main() {
           throwsA(TypeMatcher<AssertionError>()));
     });
 
+    test(
+        'Cron().parse() throws exception if current has been called before first next or previous call',
+        () {
+      var cronIterator = Cron().parse("* * * * *", "Europe/Berlin");
+      expect(
+          () => cronIterator.current(), throwsA(TypeMatcher<AssertionError>()));
+    });
+
     group("delivers", () {
       test('correct locations', () {
         TZDateTime date = normalizedDate() as TZDateTime;

--- a/test/cron_parser_test.dart
+++ b/test/cron_parser_test.dart
@@ -61,14 +61,6 @@ void main() {
         throwsA(TypeMatcher<AssertionError>()));
   });
 
-  test(
-      'Cron().parse() throws exception if current has been called before first next call',
-      () {
-    var cronIterator = Cron().parse("* * * * *", "Europe/Berlin");
-    expect(
-        () => cronIterator.current(), throwsA(TypeMatcher<AssertionError>()));
-  });
-
   group("Cron().parse() delivers", () {
     test('correct locations', () {
       TZDateTime date = normalizedDate() as TZDateTime;
@@ -546,7 +538,7 @@ void main() {
       expect(cronIterator.previous(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 01, 4)));
       expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 02, 4)));
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 03, 4)));
     });
 
     test('next month selection starting from date', () {
@@ -576,7 +568,7 @@ void main() {
       expect(cronIterator.previous(),
           equals(TZDateTime(getLocation("Europe/Berlin"), 2020, 01, 4)));
       expect(cronIterator.previous(),
-          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 02, 4)));
+          equals(TZDateTime(getLocation("Europe/Berlin"), 2019, 03, 4)));
     });
 
     test('next weekdays range starting from date', () {
@@ -988,6 +980,24 @@ void main() {
       expect(cronIterator.previous(),
           equals(TZDateTime(getLocation("Europe/London"), 2020, 3, 31, 22)));
       print(cronIterator.previous());
+    });
+  });
+
+  group('Smoke tests', () {
+    test('0 19 7 8 * (previous)', () {
+      TZDateTime startDate =
+          TZDateTime(getLocation("Europe/London"), 2021, 7, 12);
+      var cronIterator = Cron().parse("0 19 7 8 *", "Europe/London", startDate);
+      expect(cronIterator.previous(),
+          equals(TZDateTime(getLocation("Europe/London"), 2020, 8, 7, 19)));
+    });
+
+    test('0 19 7 8 * (next)', () {
+      TZDateTime startDate =
+          TZDateTime(getLocation("Europe/London"), 2021, 7, 12);
+      var cronIterator = Cron().parse("0 19 7 8 *", "Europe/London", startDate);
+      expect(cronIterator.next(),
+          equals(TZDateTime(getLocation("Europe/London"), 2021, 8, 7, 19)));
     });
   });
 }


### PR DESCRIPTION
## Description
As request in #1 it's sometimes helpful, to get the previous cron. This PR adds the option to use `cronIterator.previous()`:
```dart
TZDateTime startDate = TZDateTime(getLocation("Europe/London"), 2020, 4, 01);
var cronIterator = Cron().parse("0 * * * *", "Europe/London", startDate);
TZDateTime previousDate = cronIterator.previous(); // 2020-03-31 23:00:00.000+0100
TZDateTime beforePreviousDate = cronIterator.previous(); // 2020-03-31 22:00:00.000+0100
```

Use this in your `pubspec.yaml`, until this PR is open:
```yaml
cron_parser:
    git:
      url: https://github.com/nilsreichardt/cron-parser
      ref: add-previous
```

## Note
This branch is based on https://github.com/rbubke/cron-parser/pull/4. So it makes sense to first review https://github.com/rbubke/cron-parser/pull/4, merge it into `master`, merge `master` into branch and then review this PR.

## Related Tickets
Closes #1 