### PR TITLE
test: add initialization of timezone database, to able to run specific tests

### DIFF
--- a/test/cron_parser_test.dart
+++ b/test/cron_parser_test.dart
@@ -1,10 +1,13 @@
 import 'package:test/test.dart';
 import 'package:timezone/standalone.dart';
 import 'package:timezone/timezone.dart';
+import 'package:timezone/data/latest.dart' as tz;
 
 import '../lib/cron_parser.dart';
 
 void main() {
+  tz.initializeTimeZones();
+
   group('Cron().parse()', () {
     TZDateTime normalizedDate(
         [DateTime? dateTime, String locationName = "Europe/Berlin"]) {


### PR DESCRIPTION
Without the initialization of the timezone database, you are still able to run all tests at once, but if you try to run a specific test, you will get this error: 
```
Location with the name "Europe/Berlin" doesn't exist
```

You see the described behavior also in this video:

https://user-images.githubusercontent.com/24459435/139539748-6181a188-5cae-4e20-9888-cc168de3e058.mov
